### PR TITLE
Raise NotImplementedError if one tries to export MAD

### DIFF
--- a/beamline/lattice.py
+++ b/beamline/lattice.py
@@ -604,7 +604,7 @@ class Lattice(object):
                                                                        :-2])
             # [:-2] slicing to remove trailing space and ','
         elif format == 'mad':
-            pass
+            raise NotImplementedError("Not implemented, yet")
 
         return fmtstring
 


### PR DESCRIPTION
* Export of MAD-8- and MAD-X-lattices is not implemented, yet, but one does
  not know until one reads the code. Now an Error is raised to alert the
  user of this library.